### PR TITLE
Adds optional support for `std::error::Error`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ documentation = "https://docs.rs/sen6x"
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
 defmt = { version = "0.3.10", optional = true }
+thiserror = { version = "2.0.12", optional = true, default-features = false }
 
 [dev-dependencies]
 embedded-hal-mock = { version = "0.11.1", features = ["embedded-hal-async"] }
@@ -34,6 +35,7 @@ sen63c = []
 sen65 = []
 sen66 = []
 sen68 = []
+std = ["thiserror"]
 
 [package.metadata.docs.rs]
 features = ["async"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@
 //! ```bash
 //! cargo xtask test-features
 //! ```
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 
 // Ensure only one SEN6X sensor variant feature is enabled at a time
 #[cfg(feature = "sen60")]
@@ -212,18 +212,40 @@ type Result<T> = core::result::Result<T, Sen6xError>;
 /// Represents any error that may happen during communication.
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
 pub enum Sen6xError {
     /// An error occurred while reading from the module.
+    #[cfg_attr(
+        feature = "std",
+        error("An error occurred while reading from the SEN6x module")
+    )]
     ReadI2CError,
     /// An error occurred while writing to the module.
+    #[cfg_attr(
+        feature = "std",
+        error("An error occurred while writing to the SEN6x module")
+    )]
     WriteI2CError,
     /// The sensor module is in a state that does not permit this command
+    #[cfg_attr(
+        feature = "std",
+        error("The SEN6x module is in a state that does not permit this command")
+    )]
     InvalidState,
     /// The sensor module returned data which could not be parsed
+    #[cfg_attr(
+        feature = "std",
+        error("The SEN6x module returned data which could not be parsed")
+    )]
     InvalidData,
     /// Too much data was provided to the driver implementation
+    #[cfg_attr(
+        feature = "std",
+        error("The SEN6x module provided toto much data to the driver implementation")
+    )]
     TooMuchData,
     /// CRC related error
+    #[cfg_attr(feature = "std", error("CRC failure on SEN6x data"))]
     CrcError(CrcError),
 }
 


### PR DESCRIPTION
This PR adds a crate feature `std` that, when enabled, implements `std::error::Error` for `Sen6xError` via the [`thiserror`](https://github.com/dtolnay/thiserror) crate.

This enables idiomatic error handling and especially relevant to Linux devices accessing the SEN6x, such as a Raspberry Pi. I'm using this PR in [sen6x-logger](https://github.com/sbruton/sen6x-logger).