### PR TITLE
Adds optional support for `serde` on `MeasuredSample`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ documentation = "https://docs.rs/sen6x"
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
 defmt = { version = "0.3.10", optional = true }
+serde = { version = "1.0.219", features = ["derive"], optional = true }
 
 [dev-dependencies]
 embedded-hal-mock = { version = "0.11.1", features = ["embedded-hal-async"] }
@@ -34,6 +35,7 @@ sen63c = []
 sen65 = []
 sen66 = []
 sen68 = []
+serde = ["dep:serde"]
 
 [package.metadata.docs.rs]
 features = ["async"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ documentation = "https://docs.rs/sen6x"
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
 defmt = { version = "0.3.10", optional = true }
-serde = { version = "1.0.219", features = ["derive"], optional = true }
+serde = { version = "1.0.219", features = [
+    "derive",
+], optional = true, default-features = false }
 thiserror = { version = "2.0.12", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,6 +236,7 @@ impl From<CrcError> for Sen6xError {
 /// Represents a measured sample from the sensor module.
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MeasuredSample {
     /// PM1 concentration in µg/m³
     pub pm1: f32,


### PR DESCRIPTION
This PR adds a crate feature `serde` that, when enabled, annotates the `MeasuredSample` struct to derive [`serde`](https://serde.rs) serialization and deserialization routines.

Output from [`serde_json`](https://github.com/serde-rs/json)
```json
{
  "pm1": 0.4,
  "pm2_5": 0.4,
  "pm4": 0.5,
  "pm10": 0.5,
  "humidity": 44.11,
  "temperature": 19.915,
  "co2": 558,
  "voc": 1.0,
  "nox": 9.0
}
```

Output from [`csv`](https://github.com/BurntSushi/rust-csv)
```csv
pm1,pm2_5,pm4,pm10,humidity,temperature,co2,voc,nox
0.2,0.3,0.3,0.3,44.18,20.075,569,1.0,9.0
```

Would be a convenience especially relevant to Linux devices accessing the SEN6x, such as a Raspberry Pi. I'm using this PR in [sen6x-logger](https://github.com/sbruton/sen6x-logger).